### PR TITLE
Remove name parameter

### DIFF
--- a/main.js
+++ b/main.js
@@ -27,6 +27,6 @@ module.exports.loop = function () {
     needMoreSnowflakes = Object.keys(Game.creeps).length < Memory.MAX_CREEPS;
     canCreateSnowflake = Game.spawns['Arendelle'].canCreateCreep([MOVE,MOVE,WORK,CARRY]) == OK;
     if(needMoreSnowflakes && canCreateSnowflake) {
-        Game.spawns['Arendelle'].createCreep( [MOVE,MOVE,WORK,CARRY], 'Snowflake' + (Object.keys(Game.creeps).length + 1) );
+        Game.spawns['Arendelle'].createCreep( [MOVE,MOVE,WORK,CARRY] );
     }
 }


### PR DESCRIPTION
To avoid attempting to spawn creeps with duplicate names. Omit the
parameter to get a randomly generated name.
Fixes #1.
http://support.screeps.com/hc/en-us/articles/205990342-StructureSpawn#createCreep
