### PR TITLE
Add notifications for room controller ticksToDowngrade

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,5 +1,6 @@
 Memory.MAX_CREEPS = 3;
 Memory.WARN_RATE = 0.9; // send a warning notification when the downgrade timer has reached 90% (meaning 10% lost / ticks passed)
+Memory.notified; // whether a notification has been sent for this instance of a downgrade timer drop
 
 var taskHarvest = require('task.harvest');
 var taskHaul = require('task.haul');
@@ -35,8 +36,12 @@ module.exports.loop = function () {
 }
 
 function notifications() {
-    if( (Game.rooms.W53N6.controller.level == 2 && Game.rooms.W53N6.controller.ticksToDowngrade < 5000 * Memory.WARN_RATE) ||
-        (Game.rooms.W53N6.controller.level == 3 && Game.rooms.W53N6.controller.ticksToDowngrade < 10000 * Memory.WARN_RATE) ) {
-        Game.notify('Room controller at level ' + Game.rooms.W53N6.controller.level + ' has a downgrade timer at ' + Game.rooms.W53N6.controller.ticksToDowngrade, 15);
+    if( !Memory.notified && (Game.rooms.W53N6.controller.level == 2 && Game.rooms.W53N6.controller.ticksToDowngrade <= 5000 * Memory.WARN_RATE) ||
+                            (Game.rooms.W53N6.controller.level == 3 && Game.rooms.W53N6.controller.ticksToDowngrade <= 10000 * Memory.WARN_RATE) ) {
+        Game.notify('Room controller at level ' + Game.rooms.W53N6.controller.level + ' has a downgrade timer at ' + Game.rooms.W53N6.controller.ticksToDowngrade);
+        Memory.notified = true; // notification has been sent, don't keep sending one every tick
+    } else if( Memory.notified && (Game.rooms.W53N6.controller.level == 2 && Game.rooms.W53N6.controller.ticksToDowngrade > 5000 * Memory.WARN_RATE) ||
+                                  (Game.rooms.W53N6.controller.level == 3 && Game.rooms.W53N6.controller.ticksToDowngrade > 10000 * Memory.WARN_RATE) ) {
+        Memory.notified = false; // downgrade timer has gone above warning rate, reset notification sent indicator so a notification will be sent next time it drops
     }
 }

--- a/main.js
+++ b/main.js
@@ -1,6 +1,8 @@
 Memory.MAX_CREEPS = 3;
 Memory.WARN_RATE = 0.9; // send a warning notification when the downgrade timer has reached 90% (meaning 10% lost / ticks passed)
 Memory.notified; // whether a notification has been sent for this instance of a downgrade timer drop
+Memory.REASSURE_INTERVAL = 5000;
+Memory.lastAccidentTick;
 
 var taskHarvest = require('task.harvest');
 var taskHaul = require('task.haul');
@@ -43,5 +45,14 @@ function notifications() {
     } else if( Memory.notified && (Game.rooms.W53N6.controller.level == 2 && Game.rooms.W53N6.controller.ticksToDowngrade > 5000 * Memory.WARN_RATE) ||
                                   (Game.rooms.W53N6.controller.level == 3 && Game.rooms.W53N6.controller.ticksToDowngrade > 10000 * Memory.WARN_RATE) ) {
         Memory.notified = false; // downgrade timer has gone above warning rate, reset notification sent indicator so a notification will be sent next time it drops
+    }
+    
+    if(!Memory.lastAccidentTick) {
+        //Memory.lastAccidentTick = Game.time;
+        Memory.lastAccidentTick = 13776040; // my first tick in my first room
+    }
+    ticksSinceLastAccident = Game.time - Memory.lastAccidentTick;
+    if( ticksSinceLastAccident > 0 && (ticksSinceLastAccident % Memory.REASSURE_INTERVAL == 0) ) {
+        Game.notify('Everything is A-OK 👍\nTicks since last accident: ' + ticksSinceLastAccident, 0);
     }
 }

--- a/main.js
+++ b/main.js
@@ -1,8 +1,10 @@
 Memory.MAX_CREEPS = 3;
 Memory.WARN_RATE = 0.9; // send a warning notification when the downgrade timer has reached 90% (meaning 10% lost / ticks passed)
-Memory.notified; // whether a notification has been sent for this instance of a downgrade timer drop
+if(Memory.notified == undefined) // whether a notification has been sent for this instance of a downgrade timer drop
+    Memory.notified = false;
 Memory.REASSURE_INTERVAL = 5000;
-Memory.lastAccidentTick;
+if(Memory.ticksSinceLastAccident == undefined)
+    Memory.ticksSinceLastAccident = Game.time - 13776040; // my first tick in my first room
 
 var taskHarvest = require('task.harvest');
 var taskHaul = require('task.haul');
@@ -38,21 +40,21 @@ module.exports.loop = function () {
 }
 
 function notifications() {
-    if( !Memory.notified && (Game.rooms.W53N6.controller.level == 2 && Game.rooms.W53N6.controller.ticksToDowngrade <= 5000 * Memory.WARN_RATE) ||
-                            (Game.rooms.W53N6.controller.level == 3 && Game.rooms.W53N6.controller.ticksToDowngrade <= 10000 * Memory.WARN_RATE) ) {
-        Game.notify('Room controller at level ' + Game.rooms.W53N6.controller.level + ' has a downgrade timer at ' + Game.rooms.W53N6.controller.ticksToDowngrade);
-        Memory.notified = true; // notification has been sent, don't keep sending one every tick
-    } else if( Memory.notified && (Game.rooms.W53N6.controller.level == 2 && Game.rooms.W53N6.controller.ticksToDowngrade > 5000 * Memory.WARN_RATE) ||
-                                  (Game.rooms.W53N6.controller.level == 3 && Game.rooms.W53N6.controller.ticksToDowngrade > 10000 * Memory.WARN_RATE) ) {
-        Memory.notified = false; // downgrade timer has gone above warning rate, reset notification sent indicator so a notification will be sent next time it drops
+    if(Game.rooms.W53N6.controller.ticksToDowngrade <= 10000 * Memory.WARN_RATE) {
+        if(Memory.notified == false) {
+            Game.notify('Room controller at level ' + Game.rooms.W53N6.controller.level + ' has a downgrade timer at ' + Game.rooms.W53N6.controller.ticksToDowngrade);
+            Memory.notified = true;
+        }
+        Memory.ticksSinceLastAccident = 0; // ;(
+    } else if(Game.rooms.W53N6.controller.ticksToDowngrade > 10000 * Memory.WARN_RATE) {
+        if(Memory.notified == true) {
+            Memory.notified = false;
+        }
+        Memory.ticksSinceLastAccident++;
     }
     
-    if(!Memory.lastAccidentTick) {
-        //Memory.lastAccidentTick = Game.time;
-        Memory.lastAccidentTick = 13776040; // my first tick in my first room
-    }
-    ticksSinceLastAccident = Game.time - Memory.lastAccidentTick;
-    if( ticksSinceLastAccident > 0 && (ticksSinceLastAccident % Memory.REASSURE_INTERVAL == 0) ) {
-        Game.notify('Everything is A-OK 👍\nTicks since last accident: ' + ticksSinceLastAccident, 0);
+    
+    if( Memory.ticksSinceLastAccident > 0 && (Memory.ticksSinceLastAccident % Memory.REASSURE_INTERVAL == 0) ) {
+        Game.notify('Everything is A-OK 👍\nTicks since last accident: ' + Memory.ticksSinceLastAccident, 0);
     }
 }

--- a/main.js
+++ b/main.js
@@ -1,4 +1,5 @@
 Memory.MAX_CREEPS = 3;
+Memory.WARN_RATE = 0.9; // send a warning notification when the downgrade timer has reached 90% (meaning 10% lost / ticks passed)
 
 var taskHarvest = require('task.harvest');
 var taskHaul = require('task.haul');
@@ -28,5 +29,14 @@ module.exports.loop = function () {
     canCreateSnowflake = Game.spawns['Arendelle'].canCreateCreep([MOVE,MOVE,WORK,CARRY]) == OK;
     if(needMoreSnowflakes && canCreateSnowflake) {
         Game.spawns['Arendelle'].createCreep( [MOVE,MOVE,WORK,CARRY] );
+    }
+    
+    notifications();
+}
+
+function notifications() {
+    if( (Game.rooms.W53N6.controller.level == 2 && Game.rooms.W53N6.controller.ticksToDowngrade < 5000 * Memory.WARN_RATE) ||
+        (Game.rooms.W53N6.controller.level == 3 && Game.rooms.W53N6.controller.ticksToDowngrade < 10000 * Memory.WARN_RATE) ) {
+        Game.notify('Room controller at level ' + Game.rooms.W53N6.controller.level + ' has a downgrade timer at ' + Game.rooms.W53N6.controller.ticksToDowngrade, 15);
     }
 }


### PR DESCRIPTION
Send one notification if the room controller's [downgrade timer](http://support.screeps.com/hc/en-us/articles/207711889-StructureController#ticksToDowngrade) drops below a specified percentage of full. Also send an occasional notification if everything is going well.
